### PR TITLE
fix: Coverage

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,10 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    coverage: {
+      all: true,
+      include: ['kata'],
+    },
     globals: true,
   },
 });


### PR DESCRIPTION
Only collect code coverage from `kata` folder